### PR TITLE
Update cloud_firestore plugin to fix a crash on Android with leaking …

### DIFF
--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.7"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 
   get_it: ^4.0.2
 
-  cloud_firestore: ^0.13.5
+  cloud_firestore: ^0.13.7
 
   firebase_storage: ^3.1.5
 


### PR DESCRIPTION
…listeners

https://github.com/FirebaseExtended/flutterfire/issues/2390
https://github.com/FirebaseExtended/flutterfire/pull/2733

cloud_firestore version 0.13.7 #Clean up snapshot listeners when Android Activity is destroyed.